### PR TITLE
Nested iteration fails

### DIFF
--- a/src/AbstractTypedArray.php
+++ b/src/AbstractTypedArray.php
@@ -2,7 +2,7 @@
 
 namespace TypedArray;
 
-abstract class AbstractTypedArray extends \ArrayIterator
+abstract class AbstractTypedArray extends \ArrayObject implements \IteratorAggregate
 {
     /**
      * @var callable
@@ -53,4 +53,11 @@ abstract class AbstractTypedArray extends \ArrayIterator
             throw new \InvalidArgumentException('Expected ' . $this->type . ', got ' . gettype($value));
         }
     }
+
+    public function getIterator()
+    {
+        return new \ArrayIterator($this);
+    }
+
+
 }

--- a/src/AbstractTypedArray.php
+++ b/src/AbstractTypedArray.php
@@ -2,7 +2,7 @@
 
 namespace TypedArray;
 
-abstract class AbstractTypedArray extends \ArrayObject implements \IteratorAggregate
+abstract class AbstractTypedArray extends \ArrayObject
 {
     /**
      * @var callable

--- a/src/AbstractTypedArray.php
+++ b/src/AbstractTypedArray.php
@@ -53,11 +53,4 @@ abstract class AbstractTypedArray extends \ArrayObject
             throw new \InvalidArgumentException('Expected ' . $this->type . ', got ' . gettype($value));
         }
     }
-
-    public function getIterator()
-    {
-        return new \ArrayIterator($this);
-    }
-
-
 }

--- a/test/IterationTest.php
+++ b/test/IterationTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace TypedArray\Test;
+
+class IterationTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider arrayProvider
+     */
+    public function testNestedIteration($class, array $values)
+    {
+        $array = new $class();
+
+        // Build an array using general array access
+        array_map(function ($value) use ($array) {
+            $array[] = $value;
+        }, $values);
+
+        $i = 0;
+        foreach($array as $a){
+            foreach($array as $b){
+                $i++;
+            }
+        }
+
+        $this->assertEquals(count($array)*count($array), $i, "Wrong number of nested iterations");
+    }
+
+    public function arrayProvider()
+    {
+        return array(
+            array('TypedArray\\ArrayArray', array(array("hello"), array("world"))),
+            array('TypedArray\\BoolArray', array(true, false)),
+            array('TypedArray\\CallableArray', array(function () {}, 'is_int')),
+            array('TypedArray\\FloatArray', array(1.0, -1.23)),
+            array('TypedArray\\IntArray', array(1, -1, 2, 3)),
+            array('TypedArray\\NumericArray', array(0, -1, 1, '4', '12E-4', 1.23)),
+            array('TypedArray\\ObjectArray', array(new \stdClass(), new \Exception)),
+            array('TypedArray\\ResourceArray', array(STDIN, STDOUT)),
+            array('TypedArray\\ScalarArray', array('foo', 1, 2.3, true)),
+            array('TypedArray\\StringArray', array('foo', 'bar', 'hello world')),
+        );
+    }
+}

--- a/test/IterationTest.php
+++ b/test/IterationTest.php
@@ -16,14 +16,21 @@ class IterationTest extends \PHPUnit_Framework_TestCase
             $array[] = $value;
         }, $values);
 
-        $i = 0;
-        foreach($array as $a){
-            foreach($array as $b){
-                $i++;
+        $length = count($array);
+        $outerSteps = 0;
+        $allSteps = 0;
+        foreach($array as $outerItem){
+            $outerSteps++;
+            $innerSteps = 0;
+            foreach($array as $innerItem){
+                $innerSteps++;
+                $allSteps++;
             }
+            $this->assertEquals($length, $innerSteps,"Wrong number of inner-iterations within outer step $outerSteps");
         }
+        $this->assertEquals($length, $outerSteps, "Wrong number of outer-iterations");
 
-        $this->assertEquals(count($array)*count($array), $i, "Wrong number of nested iterations");
+        $this->assertEquals($length * $length, $allSteps, "Wrong number of combined iterations");
     }
 
     public function arrayProvider()
@@ -39,6 +46,8 @@ class IterationTest extends \PHPUnit_Framework_TestCase
             array('TypedArray\\ResourceArray', array(STDIN, STDOUT)),
             array('TypedArray\\ScalarArray', array('foo', 1, 2.3, true)),
             array('TypedArray\\StringArray', array('foo', 'bar', 'hello world')),
+            array('TypedArray\\IntArray', array(/* Zero items*/ )),
+            array('TypedArray\\IntArray', array(1 /* One item only*/ )),
         );
     }
 }


### PR DESCRIPTION
Failing test provided, knew to test this because I had the same problem with some legacy code once. The problem is that every `foreach` loop uses the same object for iteration, meaning that your "progress" in each loop is accidentally shared. 

IIRC I solved it then with IteratorAggregate, but it didn't involve any type-checking so I'm not entirely certain if the same fix is applicable here. With the fix, a fresh independent iterator is supplied to every loop-construct.
